### PR TITLE
ノートのアクションが保存されないバグの修正

### DIFF
--- a/app/views/notes/edit.html.erb
+++ b/app/views/notes/edit.html.erb
@@ -43,7 +43,7 @@
             </div>
 
             <div style="flex: 4; overflow-y: auto;">
-              <%= f.fields_for :actions do |a| %>
+              <%= f.fields_for :action do |a| %>
                 <label class="form-label bg-light px-2 py-1 w-100">行動<span class="text-muted" style="font-size: 0.75rem;">　（行動は3個以内を目安に入力してみましょう）</span></label>
                 <%= a.text_area :content, class: "form-control border-0 h-100", style: "resize: none; outline: none; box-shadow: none;"  %>
               <% end %>

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -43,7 +43,7 @@
             </div>
 
             <div style="flex: 4; overflow-y: auto;">
-              <%= f.fields_for :actions do |a| %>
+              <%= f.fields_for :action do |a| %>
                 <label class="form-label bg-light px-2 py-1 w-100">行動<span class="text-muted" style="font-size: 0.75rem;">　（行動は3個以内を目安に入力してみましょう）</span></label>
                 <%= a.text_area :content, class: "form-control border-0 h-100", style: "resize: none; outline: none; box-shadow: none;"  %>
               <% end %>


### PR DESCRIPTION
ノートのアクションが保存されないバグを修正しました。
原因は、actionを複数形で記述していました。

```ruby
# edit.html.erb / new.html.erb
            <div style="flex: 4; overflow-y: auto;">
            # 下記がactionsになっていたため、修正
              <%= f.fields_for :action do |a| %>
                <label class="form-label bg-light px-2 py-1 w-100">行動<span class="text-muted" style="font-size: 0.75rem;">　（行動は3個以内を目安に入力してみましょう）</span></label>
                <%= a.text_area :content, class: "form-control border-0 h-100", style: "resize: none; outline: none; box-shadow: none;"  %>
              <% end %>
            </div>
```