### PR TITLE
エラー文の日本語化に対応

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,5 +1,5 @@
 <div class="d-flex justify-content-center align-items-center min-vh-100">
-  <div class="container bg-light d-flex justify-content-center align-items-center" style="height: 60vh; width: 60vw;">
+  <div class="container bg-light d-flex justify-content-center align-items-center" style="min-height: 60vh; width: 60vw;">
     <div>
       <h2 class="text-center">新規会員登録</h2>
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,8 +5,10 @@ ja:
         email: "メールアドレス"
         password: "パスワード"
         password_confirmation: "パスワード(確認用)"
+        encrypted_password: "パスワード(確認用)"
         remember_me: "ログイン状態を保持する"
   errors:
     messages:
       confirmation: "パスワードが一致していません"
       taken: "このメールアドレスはすでに登録されています"
+      blank: "を入力してください"


### PR DESCRIPTION
新規会員登録画面において、未入力の項目がある際に、日本語化ファイルの記述が見つからずエラー文が発生していた。
config/locales/ja.ymlに下記を追記して対応。

```ruby
ja:
  activerecord:
    attributes:
      user:
        encrypted_password: "パスワード(確認用)"  # 追記
  errors:
    messages:
      blank: "を入力してください"  # 追記
```

また、エラー文が表示された際、背景のグレーからはみ出ていたため、下記の通り修正。
```ruby
# app/views/devise/registrations
# 背景のグレーの高さを、可変するように修正
# style="height: 60vh; であったため、min-height: 60vh;に修正
  <div class="container bg-light d-flex justify-content-center align-items-center" style="min-height: 60vh; width: 60vw;">
```
![画像](https://i.gyazo.com/49fd51e44701c2bc28d7f858e9e8d192.png)