### PR TITLE
新規登録 プライバシー対応/ノート一覧への導線

### DIFF
--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -2,7 +2,7 @@
   <ul class="nav flex-column">
     <li class="nav-item">
       <a href="/notes" class="nav-link fs-5 text-white">
-        <i class="bi bi-book"></i> ノート一覧
+        <i class="bi bi-book"></i> ノート一覧へ
       </a>
     </li>
   </ul>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -8,7 +8,8 @@ ja:
         encrypted_password: "パスワード(確認用)"
         remember_me: "ログイン状態を保持する"
   errors:
+    format: "%{message}"
     messages:
       confirmation: "パスワードが一致していません"
-      taken: "このメールアドレスはすでに登録されています"
-      blank: "を入力してください"
+      taken: "登録できませんでした。入力内容をご確認ください"
+      blank: "%{attribute}を入力してください"


### PR DESCRIPTION
新規登録において、「メールアドレスはすでに登録されています」という表示はプライバシー的に不適切であるため、
「登録できませんでした。入力内容をご確認ください」と訂正。

```ruby
# config/locales/ja.yml
  errors:
    format: "%{message}"
    messages:
      confirmation: "パスワードが一致していません"
      taken: "登録できませんでした。入力内容をご確認ください"
      blank: "%{attribute}を入力してください"
```

## 保存されたノートの表示
ノート一覧画面への動線がわかりづらいため、「ノート一覧へ」に変更
```ruby
<nav data-sidebar-target="sidebar" id="sidebar" class="bg-dark text-white p-3 border-end border-secondary" style="width: 250px; display: none;">
  <ul class="nav flex-column">
    <li class="nav-item">
      <a href="/notes" class="nav-link fs-5 text-white">
        <i class="bi bi-book"></i> ノート一覧へ  # ノート一覧から「ノート一覧へ」に修正
      </a>
    </li>
  </ul>
</nav>
```